### PR TITLE
Folder/ZIP files details

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.6.0
+^^^^^
+- Add details option ``--details`` for folders and ZIP files (:pr:`116`)
+
 0.5.0
 ^^^^^
 - Add support for spatial extent for ``osgeo`` files (via OGR/GDAL) with generic vector (GeoPackage, Shapefile, GeoJSON, GML, GPX, KML) and raster handling (GeoTIFF) (:pr:`87`, :pr:`99`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 0.4.0
 ^^^^^
 - Add support for ZIP files and folders (:pr:`79`)
-nice
+
 0.3.0
 ^^^^^
 

--- a/docs/source/howto/api.rst
+++ b/docs/source/howto/api.rst
@@ -102,8 +102,8 @@ Folders or ZIP file(s)
 
 The output of this function is the combined bbox or tbox resulting from merging all results of individual files (see: :doc:`../supportedformats/index_supportedformats`) inside the folder or zipfile. The resulting coordinate reference system  ``CRS`` of the combined bbox is always in the `EPSG: 4326 <https://epsg.io/4326>`_ system.
 
-Extracting both bounding box and time interval from a folder
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Extracting both bounding box and time interval from a folder (with details)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Code:
 

--- a/docs/source/howto/api.rst
+++ b/docs/source/howto/api.rst
@@ -92,12 +92,13 @@ Folders or ZIP file(s)
 
 ::
 
-   geoextent.fromDirectory(input, bbox, time)
+   geoextent.fromDirectory(input, bbox, time, details)
 
 **Parameters:**   
    - ``input``: a string value of directory of zipfile path    
    - ``bbox``: a boolean value to extract spatial extent (bounding box)
    - ``time``: a boolean value to extract temporal extent ( at "day" precision '%Y-%m-%d')
+   - ``details``: a boolean value to return details (geoextent) of individual files (default **False**)
 
 The output of this function is the combined bbox or tbox resulting from merging all results of individual files (see: :doc:`../supportedformats/index_supportedformats`) inside the folder or zipfile. The resulting coordinate reference system  ``CRS`` of the combined bbox is always in the `EPSG: 4326 <https://epsg.io/4326>`_ system.
 
@@ -108,7 +109,7 @@ Code:
 
 ::
 
-   geoextent.fromDirectory('folder_two_files', True, True)
+   geoextent.fromDirectory('folder_one_file', True, True, True)
 
 Output:
 
@@ -117,6 +118,6 @@ Output:
    :stderr:
 
    import geoextent.lib.extent as geoextent
-   geoextent.fromDirectory('../tests/testdata/folders/folder_two_files', True, True)
+   geoextent.fromDirectory('../tests/testdata/folders/folder_one_file', True, True, True)
 
 `folder_two_files <https://github.com/o2r-project/geoextent/blob/master/tests/testdata/folders/folder_two_files>`_

--- a/docs/source/howto/cli.rst
+++ b/docs/source/howto/cli.rst
@@ -122,7 +122,7 @@ You can enable detailed logs by passing the ``--debug`` option, or by setting th
 Details
 ^^^^^^^
 You can enable details for folders and ZIP files by passing the ``--details`` option, this option allows you to access
-to the geoextent of the individual files inside the folders/ ZIP files used to compute the total bounding box (bbox)
+to the geoextent of the individual files inside the folders/ ZIP files used to compute the aggregated bounding box (bbox)
 or time box (tbox).
 
 ::

--- a/docs/source/howto/cli.rst
+++ b/docs/source/howto/cli.rst
@@ -7,7 +7,7 @@ Basics
 
 ``geoextent`` can be called on the command line with this command :
    
-.. autoprogram:: geoextent.__main__:argparser
+.. autoprogram:: geoextent.__main__:arg_parser
    :prog: \
 
 Examples
@@ -118,3 +118,23 @@ You can enable detailed logs by passing the ``--debug`` option, or by setting th
    geoextent --debug -b -t muenster_ring_zeit.geojson
 
    GEOEXTENT_DEBUG=1 geoextent -b -t muenster_ring_zeit.geojson
+
+Details
+^^^^^^^
+You can enable details for folders and ZIP files by passing the ``--details`` option, this option allows you to access
+to the geoextent of the individual files inside the folders/ ZIP files used to compute the total bounding box (bbox)
+or time box (tbox).
+
+::
+
+   geoextent --details -b -t folder_one_file
+
+.. jupyter-execute::
+   :hide-code:
+   :stderr:
+
+   import geoextent.lib.extent as geoextent
+   geoextent.fromDirectory('../tests/testdata/folders/folder_one_file', True, True,True)
+
+
+

--- a/geoextent/__init__.py
+++ b/geoextent/__init__.py
@@ -1,3 +1,3 @@
 name = "geoextent"
 
-__version__ = '0.5.2'
+__version__ = '0.6.0'

--- a/geoextent/__init__.py
+++ b/geoextent/__init__.py
@@ -1,3 +1,3 @@
 name = "geoextent"
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/geoextent/__main__.py
+++ b/geoextent/__main__.py
@@ -1,16 +1,18 @@
-import sys, os, datetime, argparse
+import argparse
+import logging
+import os
+import sys
 import zipfile
 
-from .lib import helpfunctions as hf
-from .lib import extent
 from . import __version__ as current_version
-import logging
+from .lib import extent
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger("geoextent")
 
 help_description = '''
-geoextent is a Python library for extracting geospatial and temporal extents of a file or a directory of multiple geospatial data formats.
+geoextent is a Python library for extracting geospatial and temporal extents of a file
+ or a directory of multiple geospatial data formats.
 '''
 
 help_epilog = '''
@@ -18,10 +20,11 @@ By default, both bounding box and temporal extent are extracted.
 
 Examples:
 
-geoextent path/to/geofile.ext
+geoextent path/to/geo_file.ext
 geoextent -b path/to/directory_with_geospatial_data
 geoextent -t path/to/file_with_temporal_extent
 geoextent -b -t path/to/geospatial_files
+geoextent -b -t --details path/to/zipfile_with_geospatial_data
 '''
 
 supported_formats = '''
@@ -45,32 +48,32 @@ class readable_file_or_dir(argparse.Action):
             if not (os.path.isdir(candidate) or os.path.isfile(candidate) or zipfile.is_zipfile(candidate)):
                 raise argparse.ArgumentTypeError("{0} is not a valid directory or file".format(candidate))
             if os.access(candidate, os.R_OK):
-                setattr(namespace,self.dest,candidate)
+                setattr(namespace, self.dest, candidate)
             else:
                 raise argparse.ArgumentTypeError("{0} is not a readable directory or file".format(candidate))
 
 
-def get_argparser():
+def get_arg_parser():
     """Get arguments to extract geoextent """
     parser = argparse.ArgumentParser(
         add_help=False,
         prog='geoextent',
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage= "geoextent [-h] [--formats] [--version] [--debug] [-b] [-t] [input file]']"
+        usage="geoextent [-h] [--formats] [--version] [--debug] [--details] [-b] [-t] [input file]']"
     )
 
     parser.add_argument(
-        '-h','--help',
+        '-h', '--help',
         action='store_true',
         help='show help message and exit'
     )
-    
+
     parser.add_argument(
         '--formats',
         action='store_true',
         help='show supported formats'
     )
-    
+
     parser.add_argument(
         '--version',
         action='store_true',
@@ -81,6 +84,13 @@ def get_argparser():
         '--debug',
         help='turn on debug logging, alternatively set environment variable GEOEXTENT_DEBUG=1',
         action='store_true'
+    )
+
+    parser.add_argument(
+        '--details',
+        action='store_true',
+        default=False,
+        help='Returns details of folder/zipFiles geoextent extraction',
     )
 
     parser.add_argument(
@@ -104,76 +114,84 @@ def get_argparser():
         nargs=argparse.REMAINDER,
         help="input file or path"
     )
-    
+
     return parser
+
 
 def print_help():
     print(help_description)
-    argparser.print_help()
+    arg_parser.print_help()
     print(help_epilog)
     print_supported_formats()
+
 
 def print_supported_formats():
     print(supported_formats)
 
+
 def print_version():
     print(current_version)
 
-argparser = get_argparser()
+
+arg_parser = get_arg_parser()
 
 
 def main():
     # Check if there is no arguments, then print help
-    if len(sys.argv[1:])==0:
+    if len(sys.argv[1:]) == 0:
         print_help()
-        argparser.exit()
+        arg_parser.exit()
 
     # version, help, and formats must be checked before parse, as otherwise files are required 
-    # but argpase gives an error if allowed to be parsed first
+    # but arg parser gives an error if allowed to be parsed first
     if "--help" in sys.argv:
         print_help()
-        argparser.exit()
+        arg_parser.exit()
     if "--version" in sys.argv:
         print_version()
-        argparser.exit()
+        arg_parser.exit()
     if "--formats" in sys.argv:
         print_supported_formats()
-        argparser.exit()
-    
-    args = vars(argparser.parse_args())
+        arg_parser.exit()
+
+    args = vars(arg_parser.parse_args())
     files = args['files']
     logger.debug('Extracting from inputs %s', files)
 
     # Set logging level
-    if(args['debug']):
+    if args['debug']:
         logging.getLogger('geoextent').setLevel(logging.DEBUG)
-    if(os.environ.get('GEOEXTENT_DEBUG', None) == "1"):
+    if os.environ.get('GEOEXTENT_DEBUG', None) == "1":
         logging.getLogger('geoextent').setLevel(logging.DEBUG)
 
+    output = None
     # Check if file is exists happens in parser validation, see readable_file_or_dir
     try:
-        if os.path.isfile(os.path.join(os.getcwd(), files)) and not zipfile.is_zipfile(os.path.join(os.getcwd(),files)):
-            output = extent.fromFile(files, bbox = args['bounding_box'], tbox = args['time_box'])
-        if os.path.isdir(os.path.join(os.getcwd(), files)) or zipfile.is_zipfile(os.path.join(os.getcwd(),files)):
-            output = extent.fromDirectory(files, bbox = args['bounding_box'], tbox = args['time_box'])
+        if os.path.isfile(os.path.join(os.getcwd(), files)) and not zipfile.is_zipfile(
+                os.path.join(os.getcwd(), files)):
+            output = extent.fromFile(files, bbox=args['bounding_box'], tbox=args['time_box'])
+        if os.path.isdir(os.path.join(os.getcwd(), files)) or zipfile.is_zipfile(os.path.join(os.getcwd(), files)):
+            output = extent.fromDirectory(files, bbox=args['bounding_box'], tbox=args['time_box'], details=True)
+            if not args['details']:
+                output.pop('details', None)
 
     except Exception as e:
-        if(logger.getEffectiveLevel() >= logging.DEBUG):
+        if logger.getEffectiveLevel() >= logging.DEBUG:
             logger.exception(e)
         sys.exit(1)
-    logger.info("Output{}:".format(output))
+
     if output is None:
         raise Exception("Did not find supported files at {}".format(files))
-
-    # print output
+    else:
+        logger.info("Output{}:".format(output))
 
     if type(output) == list:
         print(str(output))
     elif type(output) == dict:
-        output.pop('details', None)
         print(str(output))
     else:
         print(output)
+
 
 if __name__ == '__main__':
     main()

--- a/geoextent/lib/handleCSV.py
+++ b/geoextent/lib/handleCSV.py
@@ -3,7 +3,6 @@ import logging
 from osgeo import gdal
 from . import helpfunctions as hf
 
-fileType = "text/csv"
 
 logger = logging.getLogger("geoextent")
 

--- a/geoextent/lib/handleRaster.py
+++ b/geoextent/lib/handleRaster.py
@@ -4,8 +4,6 @@ import osgeo.osr as osr
 import logging
 from . import helpfunctions as hf
 
-fileType = "image/tiff"
-
 logger = logging.getLogger("geoextent")
 
 
@@ -90,3 +88,4 @@ def getTemporalExtent(filePath):
 
     print('There is no time value for GeoTIFF files')
     return 'None'
+

--- a/geoextent/lib/handleVector.py
+++ b/geoextent/lib/handleVector.py
@@ -7,7 +7,6 @@ import re
 from osgeo import osr
 
 null_island = [0] * 4
-fileType = "application/shp"
 search = {"time": ["(.)*timestamp(.)*", "(.)*datetime(.)*", "(.)*time(.)*", "date$", "^date", "^begin"]}
 logger = logging.getLogger("geoextent")
 
@@ -120,7 +119,8 @@ def getBoundingBox(filepath):
 
         try:
             crs = layer.GetSpatialRef().GetAttrValue("GEOGCS|AUTHORITY", 1)
-        except Exception:
+        except Exception as e:
+            logger.debug("Error extracting EPSG CODE from layer {}: \n {}".format(layer_name, e))
             crs = None
 
         # Patch GDAL > 3.2 for GML  https://github.com/OSGeo/gdal/issues/2195
@@ -135,10 +135,11 @@ def getBoundingBox(filepath):
 
     bbox_merge = hf.bbox_merge(geo_dict, filepath)
 
+    spatial_extent = None
+
     if bbox_merge is not None:
         if len(bbox_merge) != 0:
-            spatialExtent = bbox_merge
-    else:
-        spatialExtent = None
+            spatial_extent = bbox_merge
 
-    return spatialExtent
+    return spatial_extent
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,6 +99,19 @@ def test_folder_one_file():
     assert result["tbox"] == ['2018-11-14', '2018-11-14']
 
 
+def test_folder_one_file_details():
+    result = geoextent.fromDirectory('tests/testdata/folders/folder_one_file', bbox=True, tbox=True, details=True)
+    assert "bbox" in result
+    assert "tbox" in result
+    assert "crs" in result
+    assert "details" in result
+    assert result["bbox"] == pytest.approx([7.601680, 51.948814, 7.647256, 51.974624], abs=tolerance)
+    assert result["crs"] == "4326"
+    assert result["tbox"] == ['2018-11-14', '2018-11-14']
+    details = result['details']
+    assert 'muenster_ring_zeit.geojson' in details
+
+
 def test_folder_multiple_files():
     result = geoextent.fromDirectory('tests/testdata/folders/folder_two_files', bbox=True, tbox=True)
     assert "bbox" in result

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,13 +114,7 @@ def test_folder_one_file_details():
 
 def test_folder_one_file_no_details():
     result = geoextent.fromDirectory('tests/testdata/folders/folder_one_file', bbox=True, tbox=True, details=False)
-    assert "bbox" in result
-    assert "tbox" in result
-    assert "crs" in result
     assert "details" not in result
-    assert result["bbox"] == pytest.approx([7.601680, 51.948814, 7.647256, 51.974624], abs=tolerance)
-    assert result["crs"] == "4326"
-    assert result["tbox"] == ['2018-11-14', '2018-11-14']
 
 
 def test_folder_multiple_files():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -112,6 +112,17 @@ def test_folder_one_file_details():
     assert 'muenster_ring_zeit.geojson' in details
 
 
+def test_folder_one_file_no_details():
+    result = geoextent.fromDirectory('tests/testdata/folders/folder_one_file', bbox=True, tbox=True, details=False)
+    assert "bbox" in result
+    assert "tbox" in result
+    assert "crs" in result
+    assert "details" not in result
+    assert result["bbox"] == pytest.approx([7.601680, 51.948814, 7.647256, 51.974624], abs=tolerance)
+    assert result["crs"] == "4326"
+    assert result["tbox"] == ['2018-11-14', '2018-11-14']
+
+
 def test_folder_multiple_files():
     result = geoextent.fromDirectory('tests/testdata/folders/folder_two_files', bbox=True, tbox=True)
     assert "bbox" in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,13 @@ def test_help_text_no_args(script_runner):
     assert "geoextent [-h]" in ret.stdout, "usage instructions are printed to console"
 
 
+def test_details_folder(script_runner):
+    ret = script_runner.run('geoextent', '-b', '-t', '--details', 'tests/testdata/folders/folder_one_file')
+    assert ret.success, "process should return success"
+    result = ret.stdout
+    assert "'details'" in result
+
+
 def test_error_no_file(script_runner):
     ret = script_runner.run('geoextent', 'doesntexist')
     assert not ret.success, "process should return failure"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,13 @@ def test_details_folder(script_runner):
     assert "'details'" in result
 
 
+def test_no_details_folder(script_runner):
+    ret = script_runner.run('geoextent', '-b', '-t', 'tests/testdata/folders/folder_one_file')
+    assert ret.success, "process should return success"
+    result = ret.stdout
+    assert "'details'" not in result
+
+
 def test_error_no_file(script_runner):
     ret = script_runner.run('geoextent', 'doesntexist')
     assert not ret.success, "process should return failure"


### PR DESCRIPTION
This pull request implements the '--details' argument (CLI and API). This option allows the users to explore the geoextent `bbox` or/and `tbox` of individual files inside a folder or ZIP file. Additionally, individual files return the geoextent handler (e.g `handleVector`) used to extract `bbox` or/and `tbox`.

Documentation and test updated.

Fixes #115