### PR TITLE
Change in output format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ os: linux
 dist: xenial
 language: python
 python:
-  - "3.7"
-  - "3.7-dev"  # 3.7 development branch
+  - "3.8"
+  - "nightly"
 addons:
   apt:
     sources:

--- a/geoextent/lib/extent.py
+++ b/geoextent/lib/extent.py
@@ -157,8 +157,9 @@ def fromFile(filepath, bbox=True, tbox=True, num_sample=None):
                 try:
                     if bbox:
                         spatial_extent = compute_bbox_wgs84(usedModule, filepath)
-                        metadata["bbox"] = spatial_extent['bbox']
-                        metadata["crs"] = spatial_extent['crs']
+                        if spatial_extent is not None:
+                            metadata["bbox"] = spatial_extent['bbox']
+                            metadata["crs"] = spatial_extent['crs']
                 except Exception as e:
                     logger.warning("Error for {} extracting bbox:\n{}".format(filepath, str(e)))
             elif self.task == "tbox":
@@ -170,7 +171,8 @@ def fromFile(filepath, bbox=True, tbox=True, num_sample=None):
                             if num_sample is not None:
                                 logger.warning("num_sample parameter is ignored, only applies to CSV files")
                             extract_tbox = usedModule.getTemporalExtent(filepath)
-                        metadata["tbox"] = extract_tbox
+                        if extract_tbox is not None:
+                            metadata["tbox"] = extract_tbox
                 except Exception as e:
                     logger.warning("Error extracting tbox, time format not found \n {}:".format(str(e)))
             else:

--- a/geoextent/lib/handleRaster.py
+++ b/geoextent/lib/handleRaster.py
@@ -87,5 +87,5 @@ def getTemporalExtent(filePath):
     '''
 
     print('There is no time value for GeoTIFF files')
-    return 'None'
+    return None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ def test_geojson_time_invalid(script_runner):
     ret = script_runner.run('geoextent',
                             '-t', 'tests/testdata/geojson/invalid_time.geojson')
     assert ret.success, "process should return success"
-    assert "'tbox': None" in ret.stdout
+    assert "'tbox'" not in ret.stdout
 
 
 def test_print_supported_formats(script_runner):
@@ -188,7 +188,7 @@ def test_kml_time_invalid(script_runner):
     ret = script_runner.run('geoextent', '-t', 'tests/testdata/kml/abstractviews_timeprimitive_example_error.kml')
     assert ret.success, "process should return success"
     assert ret.stderr is not None
-    assert "'tbox': None" in ret.stdout
+    assert "'tbox'" not in ret.stdout
 
 
 @pytest.mark.skipif(gdal.__version__.startswith("2"), reason="coordinate order mismatch for old GDAL versions")


### PR DESCRIPTION
Change in output format, if file does not have bbox or tbox geoextent does not return that parameter.
This pull request standardize the output, previously some cases would return "None" (String). 